### PR TITLE
disable autocomplete from mobile browsers

### DIFF
--- a/src/components/Game/Question.jsx
+++ b/src/components/Game/Question.jsx
@@ -240,7 +240,17 @@ class Question extends Component {
               })
             : <div className="answer-form-container">
                 <form onSubmit={this.handleSubmit}>
-                  <input autoFocus className="answer-input" type="text" value={this.state.currentAnswer} onChange={this.handleAnswerChange} />
+                  <input
+                    autoFocus
+                    className="answer-input"
+                    type="text"
+                    value={this.state.currentAnswer}
+                    onChange={this.handleAnswerChange}
+                    autocomplete="off"
+                    autocorrect="off"
+                    autocapitalize="off"
+                    spellcheck="false"
+                  />
                 </form>
               </div>
           }


### PR DESCRIPTION
When taking the quiz from an iPad autocomplete/correct can be annoying because it doesn't recognize the input language.
I think it's better to disable it completely