### PR TITLE
Show kana on mouseover instead of mousedown

### DIFF
--- a/src/components/ChooseCharacters/CharacterGroup.jsx
+++ b/src/components/ChooseCharacters/CharacterGroup.jsx
@@ -36,8 +36,8 @@ class CharacterGroup extends Component {
         this.props.handleToggleSelect(this.props.groupName);
         this.changeShownChars(this.getShowableCharacters('romaji'));
       }}
-      onMouseDown={()=>this.changeShownChars(this.getShowableCharacters('kana'))}
-      onMouseOut={()=>this.changeShownChars(this.getShowableCharacters('romaji'))}
+      onMouseEnter={()=>this.changeShownChars(this.getShowableCharacters('kana'))}
+      onMouseLeave={()=>this.changeShownChars(this.getShowableCharacters('romaji'))}
       onTouchStart={()=>this.changeShownChars(this.getShowableCharacters('kana'))}
       onTouchEnd={()=>this.changeShownChars(this.getShowableCharacters('romaji'))}
     >


### PR DESCRIPTION
I think the current way the kana is shown in character selection is a bit counterintuitive. You currently have to click and hold for the kana to show up, which then selects those characters. If you just wanted to look at the kana you'd then have to click again to deselect them. Showing the kana on mouseover makes a lot more sense IMO.